### PR TITLE
Updated timer to fix crashes.

### DIFF
--- a/adjustabletimer.ino
+++ b/adjustabletimer.ino
@@ -14,12 +14,12 @@ int state = 0; /*
 2 = time up
 3 = off
 */ 
-bool buttons [] = {false, false, false, false};
+bool buttons [] = {false, false, false, false, false};
 
 void setup() {
     b.begin();
     b.setBrightness(50);
-    b.playNote("G4",8); // playing a note here works fine
+    b.playNote("G4",8);
 }
 
 void loop(){
@@ -112,7 +112,7 @@ void loop(){
                 if (flashing)
                 {
                     b.allLedsOn(255,0,0);
-                    b.playNote("G4",16);// playing a note here causes the photon to crash. not sure why.
+                    b.playNote("G4",16);
                     flashing = false;
                 }
                 else


### PR DESCRIPTION
The buttons array previously had four elements, from element 0 to 3. The crashes were caused by accessing and modifying buttons[4] which was outside the bounds of the array. I fixed this by adding a fifth element to the array.